### PR TITLE
Add tip tea pot link to start menu

### DIFF
--- a/src/Components/Views/StartMenu/StartMenu.tsx
+++ b/src/Components/Views/StartMenu/StartMenu.tsx
@@ -7,6 +7,7 @@ import { useUserActions } from '../../../Hooks/useUserActions';
 import { useGlobalSettings } from '../../../Hooks/useGlobalSettings';
 import { usePlayers } from '../../../Hooks/usePlayers';
 import { Cog, Info, Trinket } from '../../../Icons/generated';
+import { BuyMeCoffee } from '../../../Icons/generated/Support';
 import {
   InitialGameSettings,
   Orientation,
@@ -279,6 +280,17 @@ const Start = () => {
           </a>
 
           <h1 className="relative flex flex-col text-3xl font-bold mt-6 mb-6 text-text-primary justify-center items-center">
+            <a
+              href="https://www.buymeacoffee.com/vikeo"
+              target="_blank"
+              onClick={() => analytics.trackEvent('click_bmc_start')}
+              className="absolute -top-3.5 flex items-center gap-0.5 opacity-40 hover:opacity-80 transition-opacity font-normal text-[10px] leading-none"
+            >
+              <BuyMeCoffee height="0.65rem" width="0.65rem" />
+              <span className="text-[10px] text-text-secondary underline">
+                Tip tea pot
+              </span>
+            </a>
             <div className="flex flex-row items-center">Life Trinket</div>
             <div className="h-[1px] w-[120%] bg-common-white opacity-50" />
             <div className="flex absolute text-xs font-medium -bottom-4">


### PR DESCRIPTION
## Summary
- Adds a small, discreet "Tip tea pot" link with BuyMeCoffee icon above the "Life Trinket" title on the start menu
- Absolutely positioned so it doesn't affect layout of other components
- Subtle opacity (40%, 80% on hover) to keep it unobtrusive

## Test plan
- [ ] Verify link appears above the title and doesn't push other elements down
- [ ] Verify link opens buymeacoffee.com/vikeo in a new tab
- [ ] Verify hover increases opacity
- [ ] Verify analytics event fires on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)